### PR TITLE
Change $no_cache to 0 by default, like it should have always been

### DIFF
--- a/includes/wp_microcaching.inc
+++ b/includes/wp_microcaching.inc
@@ -3,7 +3,7 @@
         fastcgi_ignore_headers Cache-Control Expires Vary;
 
         #Cache everything by default
-        set $no_cache 1;
+        set $no_cache 0;
 
         #Don't cache logged in users or commenters
         if ( $http_cookie ~* "comment_author_|wordpress_(?!test_cookie)|wp-postpass_" ) {


### PR DESCRIPTION
As noted in https://github.com/10up/nginx_configs/issues/9, this should be 0 to have microcaching on by default. 