### PR TITLE
Update wordpress_security.inc

### DIFF
--- a/security/wordpress_security.inc
+++ b/security/wordpress_security.inc
@@ -43,6 +43,12 @@ location ~* /wp-config {
     return 301 $redirect_to;
 }
 
+# Block user enumeration to protect user names
+# By default, WordPress redirects example.com/?author=1 to example.com/author/username
+if ($args ~* author=[0-9]) {
+  return 301 $redirect_to;
+}
+
 # Prevent Nginx from announcing which version is running to the client.
 # Danger is minor from leaving this on, but reducing the amount of
 # invormation about the server environment is always good.


### PR DESCRIPTION
Prevent user enumeration to protect user names from hackers, especially for ?author=1 admin users. Most helpful if any public author pages/links are set to a different naming convention than usernames (public address: example.com/author/firstname-lastname/, WP username: initial.lastname)
