### PR TITLE
Move php upstream definition to Nginx.conf

### DIFF
--- a/includes/php.inc
+++ b/includes/php.inc
@@ -3,7 +3,10 @@
 	#NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
 
 	include /etc/nginx/fastcgi_params;
-	fastcgi_pass unix:/run/php/php7.0-fpm.sock;
+	
+	# "php" is defined as an upstream server in nginx.conf 
+	fastcgi_pass php;
+
 	fastcgi_index index.php;
 	fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 

--- a/template/nginx.conf
+++ b/template/nginx.conf
@@ -38,5 +38,11 @@ http {
             #127.0.0.1            1;
     }
 
+    # Define PHP 
+    upstream php {
+        #server 127.0.0.1:9000;
+        server unix:/run/php/php7.0-fpm.sock;
+    }
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
### Description of the Change

Defining the upstream PHP server in the php.inc file meant that if someone wanted to upgrade PHP to a new version, they'd have to change it in the include file.  The include files are meant to be fairly standard and should not need to be edited for something that the user needs to configure, which the PHP version definitely is.  The nginx.conf and example.conf templates are where per-site customizations should be made, so we are moving the upstream designation of PHP to the nginx.conf file in order to make the include files more standardized. 

### Alternate Designs

This is how it should have been from the start and is the right way to do it. 

### Benefits

See description

### Possible Drawbacks

This is a breaking change if anyone is running these includes and pulling changes automatically.  I don't know of anyone operating like that at the moment. 

### Verification Process

Validated on test site using this configuration. 

### Checklist:

- [x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.


