### PR TITLE
Add robots.txt.inc to allow Nginx to force a specific robots.txt setup

### DIFF
--- a/includes/robots.txt.inc
+++ b/includes/robots.txt.inc
@@ -1,0 +1,9 @@
+# For internal sites that should not be discoverable by search engines,
+# force the robots.txt file to disallow indexing by all bots.  
+#
+# Do NOT use on public sites that should show up on Google. 
+
+location = /robots.txt {
+    add_header  Content-Type  text/plain;
+    return 200 "User-agent: *\nDisallow: /\n# Robots.txt controlled by Nginx";
+}

--- a/template/example.conf
+++ b/template/example.conf
@@ -14,10 +14,10 @@ server {
         index index.php;
 
         # Comment out or delete any unneeded includes
-        include nginx_configs/includes/robots.txt.inc;  # Only enable if site is non-public
+        #include nginx_configs/includes/robots.txt.inc;  # Only enable if site is non-public
         include nginx_configs/includes/performance.inc; # Speed optimizations
 	include nginx_configs/includes/ssl_config.inc;	# SSL optimizations
-	include	nginx_configs/includes/cloudflare.inc;  # Set real visitor IP address if using Cloudflare
+	#include nginx_configs/includes/cloudflare.inc;  # Set real visitor IP address if using Cloudflare
 	include nginx_configs/security/wordpress_security.inc;  # Recommended security rules
 	include nginx_configs/includes/wp_microcaching.inc;  # Short duration caching setup
 	include nginx_configs/includes/wp_subdir_multisite.inc;  # Subdirectory WP multisite rules

--- a/template/example.conf
+++ b/template/example.conf
@@ -14,13 +14,14 @@ server {
         index index.php;
 
         # Comment out or delete any unneeded includes
-        include nginx_configs/includes/performance.inc;
-	include nginx_configs/includes/ssl_config.inc;	
-	include	nginx_configs/includes/cloudflare.inc;
-	include nginx_configs/security/wordpress_security.inc;
-	include nginx_configs/includes/wp_microcaching.inc;
-	include nginx_configs/includes/wp_subdir_multisite.inc;
-        include nginx_configs/includes/expires.inc;
+        include nginx_configs/includes/robots.txt.inc;  # Only enable if site is non-public
+        include nginx_configs/includes/performance.inc; # Speed optimizations
+	include nginx_configs/includes/ssl_config.inc;	# SSL optimizations
+	include	nginx_configs/includes/cloudflare.inc;  # Set real visitor IP address if using Cloudflare
+	include nginx_configs/security/wordpress_security.inc;  # Recommended security rules
+	include nginx_configs/includes/wp_microcaching.inc;  # Short duration caching setup
+	include nginx_configs/includes/wp_subdir_multisite.inc;  # Subdirectory WP multisite rules
+        include nginx_configs/includes/expires.inc;  # Browser caching rules
 
         # The block_xmlrpc.inc file requires the variables $allow_jetpack
         # (set in the server block), $is_xmlrpc_whitelist_ip (set in the http
@@ -38,7 +39,7 @@ server {
         ssl_certificate    /etc/letsencrypt/live/example.com/fullchain.pem;
         ssl_certificate_key    /etc/letsencrypt/live/example.com/privkey.pem;
 
-        #define cache valid time for microcaching
+        #define cache valid time for microcaching (use with nginx_configs/includes/wp_microcaching.inc)
         fastcgi_cache_valid any 90s;
 
         # Jetpack connects over xmlrpc.php. If we include block_xmlrpc.inc


### PR DESCRIPTION
### Description of the Change

Added an include file to force robots.txt file to disallow all indexing by bots.  We often have the need for this on internal and stage sites.  This is a convenient way to force the value to what we want without creating individual robots.txt files on disk or making WordPress spit out the right robots.txt on these sites.  

### Benefits

On the internal sites I'm using this on, we absolutely don't want these showing up on Google, so enforcing this in Nginx makes sense.  Feels like a logical thing to have as part of the Nginx configs we have on Github so that it can be included or left off any setup.  Might be nice to have a robots.txt that forces it to be visible to bots, but that is less of a concern with the default WP robots.txt output.  

### Changelog Entry

Added:  include file for forcing robots.txt to disallow site indexing via Nginx
