### PR TITLE
Make user enumeration more specific

### DIFF
--- a/security/wordpress_security.inc
+++ b/security/wordpress_security.inc
@@ -39,16 +39,16 @@ location ~* \.(sql|sql\.gz|sql\.zip|tar|tar\.gz|lzma|pem|cer|crt|key|jks|asp|asp
 
 # Block access to wp-config.php and any files similarly named
 location ~* /wp-config {
-    return 301 $redirect_to;
+  return 301 $redirect_to;
 }
 
 # Block user enumeration to protect user names
 # By default, WordPress redirects example.com/?author=1 to example.com/author/username
-if ($args ~* author=[0-9]) {
+if ($arg_author ~* [0-9]) {
   return 301 $redirect_to;
 }
 
 # Prevent Nginx from announcing which version is running to the client.
 # Danger is minor from leaving this on, but reducing the amount of
-# invormation about the server environment is always good.
+# information about the server environment is always good.
 server_tokens off;


### PR DESCRIPTION
WordPress Exporter requests were getting blocked by the user enumeration rule previously.  This change makes the match more explicit to the `author` argument which fixes the unintended blocking of the exporter.  

The exporter requests were of the format https://example.10up.com/wp-admin/export.php?download=true&cat=0&post_author=0&post_start_date=0&post_end_date=0&post_status=0&content=pages&page_author=0&page_start_date=2020-05&page_end_date=2020-06&page_status=0&attachment_start_date=0&attachment_end_date=0&submit=Download+Export+File and our previous enumeration code would match `page_author=0` and `post_author=0` as it was just looking for anything ending with `author=[0-9]` in the arguments.  

### Verification Process

I tested this on a live site and user enumeration was still blocked, but the WordPress exporter worked.  I've tested the rest of the site and did not find anything else that was inadvertently blocked, though admittedly, there's not much functionality on this test site.  

### Changelog Entry

<!-- FIX: Update user enumeration to more specifically match the author argument. -->
