### PR TITLE
Security rule to block WP installation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Nginx Configuration Template
 ## Usage
 The `.inc` files in the `includes` and `security` directories are intended to be used as is with no modification.  For files like `blockxmlrpc.inc` that have options, these are controlled by variables that should be set in the `nginx.conf` file and the `.conf` file used for the specific site.  The `template` directory contains an example `nginx.conf` file and an `example.conf` file that contains the server block.  The `example.conf` file usually goes in the `/etc/nginx/conf.d/` directory or in the `/etc/nginx/sites-enabled/` directory.   
 
+Certain security rules block pages in WordPress that can impact expected behavior in some use-cases. Notably, the WordPress "5-minute" installation pages in `wp-admin` are blocked, which will prevent an initial installation from the browser, and sites using these configs must be created with a manual `wp-config.php` file and database import, or via the WP-CLI command line tool. 
+
 ## Installation
 The easiest way to use this repo is to clone it to your `/etc/nginx/` directory. All of the include file paths used in `/template/nginx.conf` and `/template/example.conf` will work without modification with this method:
 

--- a/security/wordpress_security.inc
+++ b/security/wordpress_security.inc
@@ -21,6 +21,12 @@ location ~* wp-includes/js/tinymce/langs/.*\.php { deny all; }
 location ~* wp-includes/js/swfupload/swfupload\.swf { deny all; }
 location ~* ^/wp-includes/js/mediaelement/.*\.swf$ { deny all; }
 
+# Since wp-admin pages are not cached, block WordPress installation pages to 
+# avoid brute force attacks and for obscurity.
+# This will block the "5 minute" web-based install process and require WP-CLI or 
+# manual wp-config.php set-up for new installations.
+location ~* wp-admin/(install|setup-config)\.php$ { return 301 $redirect_to; }
+
 # Deny access to .php files in the /wp-content/ directory (including sub-folders)
 location ~* ^/wp-content/.*\.(php|phps)$ { return 301 $redirect_to; }
 


### PR DESCRIPTION
Block pages only used for the WordPress web installation process, which are vulnerable to brute force attacks due to wp-admin pages not being cached and can cause issues with HyperDB.

### Possible Drawbacks

This will prevent web-based installations and should only be used with WP-CLI or a manual set-up of WordPress.

### Verification Process

Tested on production websites.