### PR TITLE
Modern PHP path_info security and set-up

### DIFF
--- a/includes/php.inc
+++ b/includes/php.inc
@@ -1,6 +1,10 @@
+	# prevent PHP path-walking exploit, remove if PHP files are on remote servers
 	try_files $uri =404;
+	
+	# enable and secure PATH_INFO variable
+	# activate PATH_INFO in php.ini with `cgi.fix_pathinfo = 1;`
 	fastcgi_split_path_info ^(.+\.php)(/.+)$;
-	#NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+	fastcgi_param PATH_INFO $fastcgi_path_info;
 
 	include /etc/nginx/fastcgi_params;
 	


### PR DESCRIPTION
### Description of the Change

This update makes several changes:

- recommends the php.ini `cgi.fix_pathinfo` setting is activated. This is the current default in PHP. Deactivating this was a previous security recommendation to avoid an exploit where PHP would walk the path from `index.php` to `evil.jpg` in `/evil.jpg/index.php` if the `index.php` file was not found, and attempt to evaluate the `.jpg` file. PHP now has security settings to prevent non-PHP extensions from being evaluated.

- Adds `fastcgi_param PATH_INFO $fastcgi_path_info;` - this is not a default in `/etc/nginx/fastcgi_params` files and must be added to set `PATH_INFO`. This pairs with the `fastcgi_split_path_info` setting we already include, which sets `PATH_INFO` and `SCRIPT_FILENAME` securely by ensuring `SCRIPT_FILENAME` can only be given a file with a `.php` extension.

- Recommend the `try_files $uri =404;` security config (which prevents these exploits before the PHP security layers) is only added if Nginx and PHP share a disk. If the PHP files are present on a remote server, this will create errors.

### Benefits

Enables support for `PATH_INFO` in PHP applications. WordPress does not need this for most use cases (such as pretty permalinks) but it should now be safe to provide it.

### Possible Drawbacks

None we are currently aware of, but additional testing would be helpful.

### Verification Process

Followed the testing process on https://www.nginx.com/resources/wiki/start/topics/examples/phpfcgi/ to confirm this sets the variables correctly, and ran basic updates against a WordPress 5.8. installation.
