### PR TITLE
Add TLSv1.3

### DIFF
--- a/includes/ssl_config.inc
+++ b/includes/ssl_config.inc
@@ -1,5 +1,5 @@
         # Uses https://mozilla.github.io/server-side-tls/ssl-config-generator/?hsts=no for reference        
-        ssl_protocols             TLSv1.2;
+        ssl_protocols             TLSv1.2 TLSv1.3;
         ssl_prefer_server_ciphers on;
         ssl_ciphers               ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256;
         ssl_buffer_size           8k;


### PR DESCRIPTION
Can't think of a reason not to support TLSv1.3 at this point.  I probably meant to update this a number of times in the past.